### PR TITLE
feat: implement patterns list and show commands

### DIFF
--- a/gremlin/cli.py
+++ b/gremlin/cli.py
@@ -7,7 +7,7 @@ from rich.console import Console
 from rich.table import Table
 
 from gremlin import __version__
-from gremlin.core.patterns import load_patterns, get_domain_keywords
+from gremlin.core.patterns import get_domain_keywords, load_patterns
 
 app = typer.Typer(
     name="gremlin",
@@ -130,7 +130,7 @@ def _list_patterns(all_patterns: dict) -> None:
         table.add_row(domain, str(pattern_count), keywords)
 
     console.print(table)
-    console.print(f"\n[dim]Use 'gremlin patterns show <domain>' for details[/dim]")
+    console.print("\n[dim]Use 'gremlin patterns show <domain>' for details[/dim]")
 
 
 def _show_domain_patterns(all_patterns: dict, domain: str) -> None:
@@ -151,7 +151,9 @@ def _show_domain_patterns(all_patterns: dict, domain: str) -> None:
 
     # Check domain-specific
     if domain not in domain_specific:
-        universal_categories = [item.get("category", "").lower().replace(" ", "_") for item in universal]
+        universal_categories = [
+            item.get("category", "").lower().replace(" ", "_") for item in universal
+        ]
         available = list(domain_specific.keys()) + universal_categories
         console.print(f"[red]Unknown domain: {domain}[/red]")
         console.print(f"[dim]Available: {', '.join(available)}[/dim]")

--- a/gremlin/core/prompts.py
+++ b/gremlin/core/prompts.py
@@ -49,7 +49,8 @@ def build_prompt(
     user_msg = f"""Analyze this scope for risks: **{scope}**
 
 Depth: {depth}
-Confidence threshold: Only include scenarios where you're >{threshold}% confident this could actually happen.
+Confidence threshold: Only include scenarios where you're >{threshold}% confident
+this could actually happen.
 
 Apply the breaking patterns above. For each risk scenario:
 1. State the "what if?" question

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1,9 +1,7 @@
 """Tests for domain inference."""
 
-import pytest
 
 from gremlin.core.inference import infer_domains
-
 
 # Sample domain keywords for testing
 DOMAIN_KEYWORDS = {
@@ -42,8 +40,13 @@ class TestInferDomains:
 
     def test_inference_case_insensitive(self):
         """Test that inference is case-insensitive."""
-        assert infer_domains("LOGIN", DOMAIN_KEYWORDS) == infer_domains("login", DOMAIN_KEYWORDS)
-        assert infer_domains("CHECKOUT", DOMAIN_KEYWORDS) == infer_domains("checkout", DOMAIN_KEYWORDS)
+        login_upper = infer_domains("LOGIN", DOMAIN_KEYWORDS)
+        login_lower = infer_domains("login", DOMAIN_KEYWORDS)
+        assert login_upper == login_lower
+
+        checkout_upper = infer_domains("CHECKOUT", DOMAIN_KEYWORDS)
+        checkout_lower = infer_domains("checkout", DOMAIN_KEYWORDS)
+        assert checkout_upper == checkout_lower
 
     def test_partial_keyword_match(self):
         """Test that partial matches work (keyword in larger word)."""

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -2,14 +2,11 @@
 
 from pathlib import Path
 
-import pytest
-
 from gremlin.core.patterns import (
     get_domain_keywords,
     load_patterns,
     select_patterns,
 )
-
 
 # Path to actual patterns file
 PATTERNS_PATH = Path(__file__).parent.parent / "patterns" / "breaking.yaml"


### PR DESCRIPTION
## Summary
- Wire up `gremlin patterns list` to display all pattern categories
- Wire up `gremlin patterns show <domain>` for detailed pattern view
- Support both domain-specific (auth, payments, etc.) and universal categories

## Test plan
- [x] `gremlin patterns list` displays universal (7) and domain-specific (12) categories
- [x] `gremlin patterns show payments` shows 8 payment patterns with keywords
- [x] `gremlin patterns show concurrency` works for universal categories
- [x] Invalid domain shows helpful error with available options
- [x] All 13 existing tests pass