### PR TITLE
docs: fix README inaccuracies and simplify

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,20 @@ It combines:
 ## Installation
 
 ```bash
-pip install gremlin-qa
+# Clone the repo
+git clone https://github.com/abhi10/gremlin.git
+cd gremlin
+
+# Install
+pip install -e .
+
+# Set your Anthropic API key
+export ANTHROPIC_API_KEY=sk-ant-...
 ```
 
 ## Quick Start
 
 ```bash
-# Set your Anthropic API key
-export ANTHROPIC_API_KEY=sk-ant-...
-
 # Review a feature for risks
 gremlin review "checkout flow with Stripe integration"
 
@@ -178,82 +183,9 @@ Gremlin's pattern-based approach achieves **90.7% tie rate** with baseline Claud
 
 See [Phase 2 Tier 1 Results](evals/RESULTS.md) for detailed analysis.
 
-## Gremlin Agent for Claude Code
+## Claude Code Integration
 
-In addition to the CLI tool, Gremlin provides a Claude Code agent for code review:
-
-**Usage**: Invoke the Gremlin agent during code review sessions in Claude Code
-
-**Benefits**:
-- Line-specific risk identification in PRs
-- Code-focused patterns (database, concurrency, caching)
-- Automatic pattern matching during code review
-- Optional CLI integration for comprehensive analysis
-
-**Agent Patterns**: 45-50 code-review patterns optimized for:
-- Database queries and transactions
-- Concurrency and race conditions
-- Authentication and token handling
-- Caching and distributed systems
-- Background jobs and workers
-- Observability and monitoring
-
-**When to Use**:
-- CLI: Feature-scope analysis from PRD
-- Agent: Code review in Claude Code sessions
-- Both: Comprehensive coverage (recommended)
-
-See [docs/INTEGRATION_GUIDE.md](docs/INTEGRATION_GUIDE.md) for details.
-
-## Evaluation Framework
-
-Gremlin includes a comprehensive evaluation framework for benchmarking pattern effectiveness:
-
-**Features:**
-- **Real-world validation**: Collect code samples from 100+ GitHub projects
-- **Multi-provider support**: Test across Anthropic, OpenAI, and local models
-- **Statistical rigor**: Multiple trials with consistency metrics
-- **Parallel execution**: 5-10x faster with concurrent eval runs
-- **Automated reporting**: Generate benchmark reports as marketing assets
-
-**Latest Benchmark Results (Jan 2026):**
-- ✅ **54 real-world test cases** validated across 11 domains
-- ✅ **90.7% tie rate** with baseline Claude Sonnet 4 (98.1% win/tie rate)
-- ✅ **93 patterns** achieving near-parity with state-of-the-art LLM
-- 📊 [View full results →](evals/RESULTS.md)
-
-**Quick Start:**
-```bash
-# Collect real-world code samples
-python evals/collect_projects.py --total 30
-
-# Generate eval cases
-python evals/generate_cases.py
-
-# Run evaluations (parallel mode - fast!)
-./evals/run_eval.py --all --trials 3 --parallel --workers 10
-
-# Generate benchmark report
-python evals/generate_report.py --output docs/BENCHMARK.md
-```
-
-**Advanced Usage:**
-```bash
-# Cross-model comparison
-./evals/run_eval.py --all \
-  --provider anthropic \
-  --model claude-sonnet-4-20250514 \
-  --baseline-model claude-opus-4-5-20251101 \
-  --parallel
-
-# Domain-specific evaluation
-python evals/collect_projects.py --domain auth --per-domain 10
-
-# Sequential mode (slower but easier to debug)
-./evals/run_eval.py --all --trials 3
-```
-
-See [evals/README.md](evals/README.md) for complete documentation.
+Gremlin also provides a Claude Code agent for code-focused risk analysis during PR reviews. See [docs/INTEGRATION_GUIDE.md](docs/INTEGRATION_GUIDE.md) for setup.
 
 ## Development
 


### PR DESCRIPTION
- Fix Installation: replace `pip install gremlin-qa` with source install (package not yet on PyPI)
- Remove verbose Evaluation Framework section (dev-focused, moved to evals/README.md)
- Remove "100+ GitHub projects" claim (we have 54 test cases)
- Simplify Claude Code Integration section (was too detailed)
- Remove redundant code examples

README: 297 lines → 222 lines (25% reduction)