### PR TITLE
fix(ci): add explicit permissions to workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds explicit `permissions: contents: read` to CI workflow
- Addresses CodeQL security alert #1 (CWE-275: Improper Access Control)
- Follows principle of least privilege for GITHUB_TOKEN

## Security Alert
https://github.com/abhi10/gremlin/security/code-scanning/1

## Test plan
- [ ] CI workflow runs successfully on this PR
- [ ] Security alert should auto-close after merge

🤖 Generated with [Claude Code](https://claude.ai/code)