### PR TITLE
refactor: optimize hot paths in API and CLI

### DIFF
--- a/tests/test_cli_validate.py
+++ b/tests/test_cli_validate.py
@@ -5,78 +5,85 @@ from unittest.mock import MagicMock, patch
 from typer.testing import CliRunner
 
 from gremlin.cli import app
+from gremlin.llm.base import LLMResponse
 
 runner = CliRunner()
+
+
+def _make_llm_response(text: str) -> LLMResponse:
+    """Helper to create a mock LLMResponse."""
+    return LLMResponse(text=text, model="test", provider="test")
 
 
 class TestValidateFlag:
     """Tests for the --validate CLI flag."""
 
-    @patch("gremlin.cli.get_client")
-    @patch("gremlin.cli.call_claude")
-    def test_validate_flag_makes_two_calls(self, mock_call_claude, mock_get_client):
-        """Test that --validate makes two Claude API calls."""
-        # Setup mocks
-        mock_get_client.return_value = MagicMock()
-        mock_call_claude.side_effect = [
+    @patch("gremlin.cli.get_provider")
+    def test_validate_flag_makes_two_calls(self, mock_get_provider):
+        """Test that --validate makes two LLM API calls."""
+        mock_provider = MagicMock()
+        mock_provider.complete.side_effect = [
             # First call: main analysis
-            """🔴 CRITICAL (95%)
+            _make_llm_response("""🔴 CRITICAL (95%)
 What if payment fails after order created?
 
 🟠 HIGH (88%)
-What if user clicks submit twice?""",
+What if user clicks submit twice?"""),
             # Second call: validation
-            """🔴 CRITICAL (95%)
+            _make_llm_response("""🔴 CRITICAL (95%)
 What if payment fails after order created?
 
 Validation Summary:
 - Original: 2 risks
 - Validated: 1 risk
-- Rejected: 1 (duplicate concern)""",
+- Rejected: 1 (duplicate concern)"""),
         ]
+        mock_get_provider.return_value = mock_provider
 
         _result = runner.invoke(app, ["review", "checkout", "--validate", "-o", "md"])
 
         # Should make exactly 2 API calls
-        assert mock_call_claude.call_count == 2
+        assert mock_provider.complete.call_count == 2
 
-    @patch("gremlin.cli.get_client")
-    @patch("gremlin.cli.call_claude")
-    def test_without_validate_makes_one_call(self, mock_call_claude, mock_get_client):
+    @patch("gremlin.cli.get_provider")
+    def test_without_validate_makes_one_call(self, mock_get_provider):
         """Test that without --validate, only one API call is made."""
-        mock_get_client.return_value = MagicMock()
-        mock_call_claude.return_value = """🔴 CRITICAL (95%)
+        mock_provider = MagicMock()
+        mock_provider.complete.return_value = _make_llm_response(
+            """🔴 CRITICAL (95%)
 What if payment fails?"""
+        )
+        mock_get_provider.return_value = mock_provider
 
         _result = runner.invoke(app, ["review", "checkout", "-o", "md"])
 
         # Should make exactly 1 API call
-        assert mock_call_claude.call_count == 1
+        assert mock_provider.complete.call_count == 1
 
-    @patch("gremlin.cli.get_client")
-    @patch("gremlin.cli.call_claude")
-    def test_validate_passes_scope_to_validator(self, mock_call_claude, mock_get_client):
+    @patch("gremlin.cli.get_provider")
+    def test_validate_passes_scope_to_validator(self, mock_get_provider):
         """Test that validation prompt includes the original scope."""
-        mock_get_client.return_value = MagicMock()
-        mock_call_claude.return_value = "Some risks"
+        mock_provider = MagicMock()
+        mock_provider.complete.return_value = _make_llm_response("Some risks")
+        mock_get_provider.return_value = mock_provider
 
         _result = runner.invoke(app, ["review", "auth system", "--validate", "-o", "md"])
 
         # Second call should have scope in the prompt
-        if mock_call_claude.call_count == 2:
-            second_call_args = mock_call_claude.call_args_list[1]
-            user_message = second_call_args[0][2]  # Third positional arg
+        if mock_provider.complete.call_count == 2:
+            second_call_args = mock_provider.complete.call_args_list[1]
+            user_message = second_call_args[0][1]  # Second positional arg
             assert "auth system" in user_message
 
-    @patch("gremlin.cli.get_client")
-    @patch("gremlin.cli.call_claude")
-    def test_validate_graceful_failure(self, mock_call_claude, mock_get_client):
+    @patch("gremlin.cli.get_provider")
+    def test_validate_graceful_failure(self, mock_get_provider):
         """Test that validation failure falls back to unvalidated results."""
-        mock_get_client.return_value = MagicMock()
-        mock_call_claude.side_effect = [
-            "Original risks output",
+        mock_provider = MagicMock()
+        mock_provider.complete.side_effect = [
+            _make_llm_response("Original risks output"),
             Exception("API rate limit"),  # Validation fails
         ]
+        mock_get_provider.return_value = mock_provider
 
         result = runner.invoke(app, ["review", "test", "--validate", "-o", "md"])
 


### PR DESCRIPTION
## Summary
- **Hoist `re.compile` to module level** in `api.py` — 3 regex patterns (`_HEADER_PATTERN`, `_IMPACT_PATTERN`, `_DOMAIN_PATTERN`) moved from inside `_parse_risks()` to module-level constants, avoiding recompilation on every call
- **Lazy-cache LLM provider** on `Gremlin` instance — provider created once on first `analyze()` call and reused, instead of recreating `AnthropicProvider` + `Anthropic()` HTTP client per call
- **Replace deprecated `call_claude`/`get_client`** in CLI with `get_provider()` from factory module — single provider instance reused for both analysis and optional validation pass

## Test plan
- [x] All 50 tests pass (`pytest tests/ -v`)
- [x] Ruff linting clean (`ruff check gremlin/ tests/`)
- [x] CLI validate tests updated to mock new provider pattern
- [x] Lazy init preserves backward compat (tests that construct `Gremlin()` without API key still work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)