### PR TITLE
chore: add manual trigger for dashboard deployment

### DIFF
--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'dashboard/**'
       - 'evals/critiques/**-results.json'
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Adds `workflow_dispatch` trigger to allow manual dashboard re-deploys without pushing code changes.