### PR TITLE
docs: rewrite README with focus on impact and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,441 +1,206 @@
 # Gremlin
 
-> AI critic for your codebase — surfaces breaking risk scenarios before they reach production
+> Pre-ship risk critic — surfaces what could break before it reaches production
 
-## What is Gremlin?
+[![PyPI](https://img.shields.io/pypi/v/gremlin-critic)](https://pypi.org/project/gremlin-critic/)
+[![CI](https://github.com/abhi10/gremlin/actions/workflows/ci.yml/badge.svg)](https://github.com/abhi10/gremlin/actions/workflows/ci.yml)
+[![Live Demo](https://img.shields.io/badge/Live%20Demo-Risk%20Dashboard-6366F1?style=flat-square)](https://abhi10.github.io/gremlin/)
 
-Gremlin is a **pre-ship risk critic** (CLI + Python library) that answers: **"What could break?"**
-
-Feed it a feature spec, PR diff, or plain English — Gremlin critiques it for blind spots using:
-- **107 curated risk patterns** across 14 domains (payments, auth, infra, serialization, distributed systems, and more)
-- **LLM reasoning** (applies patterns intelligently to your specific context)
-- **Structured output** (severity-ranked risk scenarios with confidence scores)
-
-## Installation
+Feed Gremlin a feature spec, PR diff, or plain English — it critiques it for blind spots using **107 curated "what if?" patterns** across 14 domains, applied by Claude.
 
 ```bash
-# Install from PyPI
 pip install gremlin-critic
-
-# Set your Anthropic API key
-export ANTHROPIC_API_KEY=sk-ant-...
+gremlin review "checkout flow with Stripe"
 ```
 
-> **For development:** `git clone https://github.com/abhi10/gremlin.git && pip install -e ".[dev]"`
+```
+🔴 CRITICAL (95%) — Webhook Race Condition
+   What if the Stripe webhook arrives before the order record is committed?
+   Impact: Payment captured but order not created.
 
-## Quick Start
+🟠 HIGH (87%) — Double Submit on Payment Button
+   What if the user clicks "Pay Now" twice rapidly?
+   Impact: Potential duplicate charges.
+```
 
-### CLI Usage
+---
+
+## Three ways to use it
+
+### 1. CLI
 
 ```bash
-# Review a feature for risks
-gremlin review "checkout flow with Stripe integration"
+# Review a feature
+gremlin review "checkout flow"
 
-# Deep analysis with lower confidence threshold
-gremlin review "auth system" --depth deep --threshold 60
+# With context (diff, file, or string)
+git diff | gremlin review "my changes" --context -
+gremlin review "auth system" --context @src/auth/login.py
 
-# See available patterns
-gremlin patterns list
+# Deep analysis, lower confidence threshold
+gremlin review "payment refunds" --depth deep --threshold 60
 
-# Show patterns for a specific domain
-gremlin patterns show payments
+# Learn from incidents
+gremlin learn "Nav showed Login after auth" --domain auth --source prod
 ```
 
-### Programmatic API (New in v0.2.0)
+### 2. GitHub Action
+
+Add to any repo — Gremlin posts a risk report on every PR automatically.
+
+```yaml
+# .github/workflows/gremlin-review.yml
+name: Gremlin Risk Review
+on: [pull_request]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install gremlin-critic
+      - run: git diff origin/${{ github.base_ref }}...HEAD > /tmp/pr-diff.txt
+      - run: |
+          python3 .github/scripts/gremlin_analyze.py \
+            "${{ github.event.pull_request.title }}" \
+            /tmp/pr-diff.txt /tmp/gremlin-report.json
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const data = JSON.parse(require('fs').readFileSync('/tmp/gremlin-report.json','utf8'));
+            const risks = data.risks || [];
+            const s = data.summary || {};
+            const body = risks.length === 0
+              ? '## Gremlin Risk Review\n\nNo risks above threshold.'
+              : `## Gremlin Risk Review\n\n**${risks.length} risk(s)** — 🔴 ${s.critical||0} critical · 🟠 ${s.high||0} high · 🟡 ${s.medium||0} medium\n\n` +
+                risks.map(r => `### ${r.severity}: ${r.title||r.scenario}\n**Confidence:** ${r.confidence}%\n\n${r.impact}`).join('\n\n---\n\n');
+            github.rest.issues.createComment({issue_number: context.issue.number, owner: context.repo.owner, repo: context.repo.repo, body});
+```
+
+Set `ANTHROPIC_API_KEY` as a repository secret (Settings → Secrets → Actions). See [the full script](.github/scripts/gremlin_analyze.py) used in this repo.
+
+### 3. Python API
 
 ```python
 from gremlin import Gremlin
 
-# Basic usage
-gremlin = Gremlin()
-result = gremlin.analyze("user authentication")
+g = Gremlin()
+result = g.analyze("checkout flow", context="Using Stripe + Next.js")
 
-# Check for critical risks
+# Check severity
 if result.has_critical_risks():
-    print(f"Found {result.critical_count} critical risks!")
-    for risk in result.risks:
-        print(f"- [{risk.severity}] {risk.scenario}")
+    print(f"{result.critical_count} critical risks found")
 
-# Multiple output formats
-json_output = result.to_json()       # JSON string
-junit_xml = result.to_junit()        # JUnit XML for CI
-llm_format = result.format_for_llm() # Concise format for agents
+# Output formats
+result.to_json()         # JSON string
+result.to_junit()        # JUnit XML for CI
+result.format_for_llm()  # Concise format for agents
 
-# Async support for agent frameworks
-result = await gremlin.analyze_async("payment processing")
+# Async
+result = await g.analyze_async("payment processing")
 
-# With additional context
-result = gremlin.analyze(
-    scope="checkout flow",
-    context="Using Stripe API with webhook handling",
-    depth="deep"
-)
+# Block CI on critical risks
+if result.has_critical_risks():
+    sys.exit(1)
 ```
 
-See the [API documentation](#programmatic-api) below for detailed usage.
-
-## Example Output
-
-```
-┌─────────────────────────────────────────────────────────────────────────────┐
-│ Risk Scenarios for: checkout flow                                           │
-└─────────────────────────────────────────────────────────────────────────────┘
-
-🔴 CRITICAL (95% confidence)
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  Webhook Race Condition
-
-  What if the Stripe webhook arrives before the order record is committed?
-
-  Impact: Payment captured but order not created. Customer charged without record.
-  Domain: payments
-
-
-🟠 HIGH (87% confidence)
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  Double Submit on Payment Button
-
-  What if the user clicks "Pay Now" twice rapidly?
-
-  Impact: Potential duplicate charges.
-  Domain: payments, concurrency
-```
+---
 
 ## Risk Dashboard
 
-Interactive visualization of Gremlin analysis results — live at **[abhi10.github.io/gremlin](https://abhi10.github.io/gremlin/)**
+Live visualization of Gremlin results applied to open-source projects — **[abhi10.github.io/gremlin](https://abhi10.github.io/gremlin/)**
 
-[![Gremlin Risk Dashboard](https://img.shields.io/badge/Live%20Demo-Risk%20Dashboard-6366F1?style=flat-square)](https://abhi10.github.io/gremlin/)
+- Heatmap · severity donut · domain bar chart · filterable risk table
+- Applied to [celery](https://github.com/celery/celery), [pydantic](https://github.com/pydantic/pydantic), and more
 
-Features:
-- **Heatmap visualization** — severity distribution across feature areas (CRITICAL / HIGH / MEDIUM / LOW)
-- **Severity donut chart** — at-a-glance risk breakdown
-- **Domain bar chart** — risk count per domain (concurrency, auth, payments...)
-- **Interactive risk table** — sortable, filterable, expandable rows with full scenario + impact
-- **Multi-project** — includes scans of [celery](https://github.com/celery/celery), [pydantic](https://github.com/pydantic/pydantic), [openclaw](https://github.com/openclaw/openclaw)
+---
+
+## Pattern Domains
+
+107 patterns across 14 domains — universal patterns run on every analysis, domain patterns trigger by keyword match:
+
+| Domain | Keywords |
+|--------|----------|
+| `payments` | checkout, stripe, billing, refund |
+| `auth` | login, session, token, oauth |
+| `database` | query, migration, transaction |
+| `concurrency` | async, queue, race, lock |
+| `infrastructure` | deploy, config, cert, secret |
+| `file_upload` | upload, image, file, cdn |
+| `api` | endpoint, rate limit, webhook |
+| + 7 more | ... |
+
+### Custom patterns
+
+```yaml
+# .gremlin/patterns.yaml — auto-loaded per project
+domain_specific:
+  image_processing:
+    keywords: [image, resize, cdn]
+    patterns:
+      - "What if EXIF rotation is ignored during resize?"
+```
+
+---
+
+## Performance
+
+**90.7% tie rate** vs. baseline Claude Sonnet across 54 real-world test cases — patterns match raw LLM quality while adding domain-specific coverage.
+
+| Metric | Result |
+|--------|--------|
+| Win / Tie Rate | 98.1% |
+| Gremlin Wins | 7.4% — patterns caught risks Claude missed |
+| Pattern Count | 107 across 14 domains |
+
+---
+
+## Installation
+
+```bash
+pip install gremlin-critic
+export ANTHROPIC_API_KEY=sk-ant-...
+```
+
+**Supports:** Anthropic (default) · OpenAI · Ollama (local, no API key needed)
+
+```python
+g = Gremlin(provider="ollama", model="llama3")  # fully local
+```
+
+**For development:**
+```bash
+git clone https://github.com/abhi10/gremlin.git
+pip install -e ".[dev]"
+pytest
+```
+
+---
 
 ## Commands
 
 | Command | Description |
 |---------|-------------|
-| `gremlin review "scope"` | Analyze a feature for QA risks |
-| `gremlin patterns list` | Show all available pattern categories |
-| `gremlin patterns show <domain>` | Show patterns for a specific domain |
-
-## Options for `review`
-
-| Option | Default | Description |
-|--------|---------|-------------|
-| `--depth` | `quick` | Analysis depth: `quick` or `deep` |
-| `--threshold` | `80` | Confidence filter (0-100) |
-| `--output` | `rich` | Output format: `rich`, `md`, `json` |
-| `--patterns` | - | Custom patterns file (YAML) |
-| `--context` | - | Additional context: string, `@file`, or `-` for stdin |
-| `--validate` | `false` | Run second pass to filter hallucinations |
-
-## Custom Patterns
-
-Add domain-specific patterns for your codebase:
-
-### Project-level (auto-loaded)
-
-```yaml
-# .gremlin/patterns.yaml
-domain_specific:
-  image_processing:
-    keywords: [image, photo, upload, resize, cdn]
-    patterns:
-      - "What if EXIF rotation is ignored during resize?"
-      - "What if CDN cache serves stale image after update?"
-```
-
-### Via `--patterns` flag
-
-```bash
-gremlin review "image upload" --patterns @my-patterns.yaml
-```
-
-### Learn from incidents
-
-```bash
-gremlin learn "Portrait images displayed sideways" --domain files --source prod-incident
-```
-
-See [docs/CUSTOM_PATTERNS.md](docs/CUSTOM_PATTERNS.md) for the full authoring guide.
-
-## Pattern Domains
-
-Gremlin includes curated patterns for these domains:
-
-- **auth** - Authentication, sessions, tokens
-- **payments** - Checkout, billing, refunds
-- **file_upload** - File handling, validation
-- **database** - Queries, transactions, migrations
-- **api** - Rate limiting, endpoints
-- **deployment** - Config, containers, environments
-- **infrastructure** - Servers, certs, resources
-- And more...
-
-## How It Works
-
-```
-User: gremlin review "checkout flow"
-         │
-         ▼
-    ┌─────────────┐
-    │ Parse scope │
-    └──────┬──────┘
-           │
-           ▼
-    ┌─────────────────┐
-    │ Infer domains   │  "checkout" → payments
-    └────────┬────────┘
-             │
-             ▼
-    ┌─────────────────┐
-    │ Select patterns │  universal + payments
-    └────────┬────────┘
-             │
-             ▼
-    ┌─────────────────┐
-    │ Build prompt    │  system.md + patterns + scope
-    └────────┬────────┘
-             │
-             ▼
-    ┌─────────────────┐
-    │ Call Claude API │
-    └────────┬────────┘
-             │
-             ▼
-    ┌─────────────────┐
-    │ Render output   │  Risk scenarios
-    └─────────────────┘
-```
-
-## Performance
-
-Gremlin's pattern-based approach achieves **90.7% tie rate** with baseline Claude Sonnet 4 across 54 real-world test cases:
-
-| Metric | Result | Notes |
-|--------|--------|-------|
-| **Tie Rate** | 90.7% | Gremlin matches baseline Claude quality |
-| **Win/Tie Rate** | 98.1% | Combined wins + ties |
-| **Gremlin Wins** | 7.4% | Cases where patterns provide unique value |
-| **Claude Wins** | 1.9% | Minor category labeling differences |
-| **Pattern Count** | 107 | Universal + domain-specific patterns |
-
-**Key Achievement**: 90% reduction in quality gaps (19% → 1.9%) through strategic pattern improvements.
-
-See [Phase 2 Tier 1 Results](evals/RESULTS.md) for detailed analysis.
-
-## Claude Code Integration
-
-Gremlin also provides a Claude Code agent for code-focused risk critique during PR reviews. See [docs/INTEGRATION_GUIDE.md](docs/INTEGRATION_GUIDE.md) for setup.
-
-## Programmatic API
-
-Gremlin can be used as a Python library for integration with CI/CD pipelines, agent frameworks, and custom tools.
-
-### Installation
-
-```bash
-pip install gremlin-critic
-# Or for development:
-pip install -e ".[dev]"
-```
-
-### Basic Usage
-
-```python
-from gremlin import Gremlin, Risk, AnalysisResult
-
-# Initialize analyzer
-gremlin = Gremlin()
-
-# Analyze a scope
-result = gremlin.analyze("checkout flow")
-
-# Access results
-print(f"Found {len(result.risks)} risks")
-print(f"Matched domains: {result.matched_domains}")
-print(f"Pattern count: {result.pattern_count}")
-```
-
-### Configuration
-
-```python
-# Use different provider/model
-gremlin = Gremlin(
-    provider="anthropic",           # anthropic, openai, ollama
-    model="claude-sonnet-4-20250514",
-    threshold=80                     # Confidence threshold
-)
-
-# Analyze with context
-result = gremlin.analyze(
-    scope="user authentication",
-    context="Using JWT with Redis session store",
-    depth="deep"                     # quick or deep
-)
-```
-
-### Output Formats
-
-```python
-# Dictionary (for JSON APIs)
-data = result.to_dict()
-
-# JSON string
-json_str = result.to_json()
-
-# JUnit XML (for CI/CD integration)
-junit_xml = result.to_junit()
-
-# LLM-friendly format (for agent consumption)
-agent_input = result.format_for_llm()
-```
-
-### Risk Analysis
-
-```python
-# Check risk severity
-if result.has_critical_risks():
-    print(f"⚠️  {result.critical_count} critical risks found")
-
-if result.has_high_severity_risks():
-    print(f"Found {result.high_count} high + {result.critical_count} critical")
-
-# Iterate through risks
-for risk in result.risks:
-    print(f"[{risk.severity}] ({risk.confidence}%)")
-    print(f"  Scenario: {risk.scenario}")
-    print(f"  Impact: {risk.impact}")
-    print(f"  Domains: {', '.join(risk.domains)}")
-```
-
-### Async Support
-
-```python
-import asyncio
-from gremlin import Gremlin
-
-async def analyze_features():
-    gremlin = Gremlin()
-
-    # Run multiple analyses concurrently
-    results = await asyncio.gather(
-        gremlin.analyze_async("checkout flow"),
-        gremlin.analyze_async("user authentication"),
-        gremlin.analyze_async("file upload")
-    )
-
-    for result in results:
-        print(f"{result.scope}: {len(result.risks)} risks")
-
-asyncio.run(analyze_features())
-```
-
-### Use Cases
-
-**1. LLM Agent Tool**
-```python
-from gremlin import Gremlin
-
-def analyze_code_risks(code: str, feature: str) -> str:
-    """Tool for LLM agents to analyze code risks."""
-    gremlin = Gremlin()
-    result = gremlin.analyze(scope=feature, context=code)
-    return result.format_for_llm()
-
-# Use with LangChain, CrewAI, AutoGen, etc.
-```
-
-**2. CI/CD Integration**
-```python
-from gremlin import Gremlin
-import sys
-
-gremlin = Gremlin(threshold=70)
-result = gremlin.analyze("PR changes", context=diff_content)
-
-# Output JUnit XML
-with open("gremlin-results.xml", "w") as f:
-    f.write(result.to_junit())
-
-# Exit with error if critical risks found
-if result.has_critical_risks():
-    print(f"❌ Found {result.critical_count} critical risks")
-    sys.exit(1)
-```
-
-**3. Custom Validation Pipeline**
-```python
-from gremlin import Gremlin
-
-def validate_feature_design(prd: str, feature_name: str) -> dict:
-    """Validate a feature design for risks."""
-    gremlin = Gremlin(depth="deep")
-    result = gremlin.analyze(feature_name, context=prd)
-
-    return {
-        "feature": feature_name,
-        "risk_count": len(result.risks),
-        "critical": result.critical_count,
-        "high": result.high_count,
-        "requires_review": result.has_high_severity_risks(),
-        "report": result.to_dict()
-    }
-```
-
-### API Reference
-
-**Classes:**
-- `Gremlin` - Main analyzer class
-- `Risk` - Individual risk finding with severity, confidence, scenario, impact
-- `AnalysisResult` - Complete analysis with multiple output formats
-
-**Methods:**
-- `Gremlin.analyze(scope, context, depth)` - Synchronous analysis
-- `Gremlin.analyze_async(scope, context, depth)` - Async analysis
-- `AnalysisResult.to_dict()` - Dictionary serialization
-- `AnalysisResult.to_json()` - JSON string
-- `AnalysisResult.to_junit()` - JUnit XML
-- `AnalysisResult.format_for_llm()` - LLM-friendly format
-- `AnalysisResult.has_critical_risks()` - Check for critical risks
-- `AnalysisResult.has_high_severity_risks()` - Check for high+ risks
-
-## Development
-
-```bash
-# Clone the repo
-git clone https://github.com/abhi10/gremlin.git
-cd gremlin
-
-# Create virtual environment
-python -m venv .venv
-source .venv/bin/activate
-
-# Install in development mode
-pip install -e ".[dev]"
-
-# Run tests
-pytest
-
-# Lint
-ruff check .
-```
+| `gremlin review "scope"` | Analyze a feature for risks |
+| `gremlin review "scope" --context @file` | With file context |
+| `git diff \| gremlin review "changes" --context -` | With diff via stdin |
+| `gremlin patterns list` | Show all pattern domains |
+| `gremlin patterns show payments` | Show patterns for a domain |
+| `gremlin learn "incident" --domain auth` | Learn from incidents |
+
+**`review` options:** `--depth quick|deep` · `--threshold 0-100` · `--output rich|md|json` · `--validate`
+
+---
 
 ## License
 
-MIT
-
-## Contributing
-
-Contributions welcome! Please open an issue first to discuss what you'd like to change.
-
-## Acknowledgments
-
-- Inspired by exploratory testing principles from James Bach and James Whittaker
-- Powered by [Claude](https://anthropic.com) from Anthropic
+MIT · Powered by [Claude](https://anthropic.com) · Inspired by exploratory testing principles from James Bach and James Whittaker


### PR DESCRIPTION
- Lead with value proposition and immediate example output
- Restructure around 3 usage paths: CLI, GitHub Action, Python API
- Add GitHub Action integration section with full workflow example
- Add gremlin learn command to commands table
- Condense verbose API reference into scannable examples
- Add provider options (Anthropic/OpenAI/Ollama) to installation
- Remove dead link to gitignored docs/INTEGRATION_GUIDE.md
- Update version reference from v0.2.0 to current