### PR TITLE
fix: address 3 Gremlin-surfaced pipeline stage risks from PR #41

### DIFF
--- a/gremlin/core/stages.py
+++ b/gremlin/core/stages.py
@@ -22,7 +22,7 @@ from typing import Any
 _SCHEMA_VERSION = "1"
 
 
-@dataclass
+@dataclass(frozen=True)
 class UnderstandingResult:
     """Output of the Understanding stage.
 
@@ -59,7 +59,7 @@ class UnderstandingResult:
         )
 
 
-@dataclass
+@dataclass(frozen=True)
 class IdeationResult:
     """Output of the Ideation stage.
 
@@ -90,7 +90,7 @@ class IdeationResult:
         )
 
 
-@dataclass
+@dataclass(frozen=True)
 class RolloutResult:
     """Output of the Rollout stage.
 
@@ -118,7 +118,7 @@ class RolloutResult:
         )
 
 
-@dataclass
+@dataclass(frozen=True)
 class JudgmentResult:
     """Output of the Judgment stage.
 


### PR DESCRIPTION
## Summary

Fixes three risks surfaced by the Gremlin Risk Review bot on PR #41:

- 🔴 **HIGH — Pipeline State Corruption Between Stages** (85%): All four stage dataclasses (`UnderstandingResult`, `IdeationResult`, `RolloutResult`, `JudgmentResult`) are now `frozen=True`. Field reassignment raises `FrozenInstanceError`, preventing silent data corruption when a stage method accidentally mutates its input artifact.

- 🟠 **MEDIUM — Error Context Loss in Pipeline** (90%): Each `_run_understanding` / `_run_ideation` / `_run_rollout` / `_run_judgment` now wraps its body in `try/except` and re-raises as `RuntimeError("[<stage> stage] original_message")` with `from e` to preserve the original traceback. Stack traces now pinpoint the failing stage.

- 🟡 **MEDIUM — Partial Pipeline Execution on Early Failure** (85%): `_write_run_artifact` in `cli.py` now writes to a `.tmp` sibling file first, then renames atomically to the target path. On POSIX, `rename()` is atomic — downstream stage commands can never read a half-written artifact if the process is interrupted mid-write.

## Test plan

- [x] `pytest -k "not Integration"` — 126 tests pass (no regressions from frozen=True)
- [x] `ruff check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)