### PR TITLE
chore: release v0.3.0 — pipeline stage commands + README update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to Gremlin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-02-21
+
+### Added
+
+**Decoupled Pipeline Stage Commands (v0.3):**
+- `gremlin understand "scope"` — Stage 1: infer domains and write `understanding.json` (no LLM call)
+- `gremlin ideate` — Stage 2: select patterns and write `scenarios.json` (no LLM call)
+- `gremlin rollout` — Stage 3: call LLM and write `results.json`
+- `gremlin judge` — Stage 4: parse and score risks, write `scores.json`; `--validate` flag for a second LLM validation pass
+- Stage artifacts are JSON-serializable and interoperable with the `Gremlin` Python API
+- Each stage reads/writes to a configurable `--run-dir` (default: `.gremlin/run/`)
+
+**Pipeline Stage Data Classes (`gremlin.core.stages`):**
+- `UnderstandingResult`, `IdeationResult`, `RolloutResult`, `JudgmentResult` — frozen dataclasses with `to_dict` / `from_dict` and schema versioning
+- Immutable (`frozen=True`) to prevent silent inter-stage data corruption
+
+**Golden Set Recall Evaluation:**
+- `evals/golden/httpx-golden.json` — 12 verified ground-truth risk fixtures from real encode/httpx issues
+- `evals/golden_eval.py` — recall measurement script (`--fast`, `--dry-run`, `--threshold` flags)
+- CI job `golden-recall` runs on every PR (single fixture, `continue-on-error`)
+
+**Robustness:**
+- Stage methods (`_run_understanding`, `_run_ideation`, `_run_rollout`, `_run_judgment`) tag exceptions with their stage name for faster debugging
+- `_write_run_artifact` uses atomic rename — no partially-written artifacts visible to downstream stages
+
+### Changed
+- `Gremlin.analyze()` refactored into five private stage methods; public API unchanged
+- `Gremlin.analyze()` now accepts `validate: bool = False` to trigger a second LLM validation pass
+
+---
+
 ## [0.1.0] - 2026-01-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -44,6 +44,35 @@ gremlin review "payment refunds" --depth deep --threshold 60
 gremlin learn "Nav showed Login after auth" --domain auth --source prod
 ```
 
+#### Pipeline stage commands (v0.3)
+
+Run each analysis stage independently — useful for caching, debugging, or building custom pipelines:
+
+```bash
+# Stage 1 — infer domains, write understanding.json (no LLM call)
+gremlin understand "checkout flow"
+
+# Stage 2 — select patterns, write scenarios.json (no LLM call)
+gremlin ideate
+
+# Stage 3 — call LLM, write results.json
+gremlin rollout
+
+# Stage 4 — parse + score risks, write scores.json
+gremlin judge
+
+# With optional validation pass
+gremlin judge --validate
+
+# Custom run directory (default: .gremlin/run/)
+gremlin understand "auth" --run-dir /tmp/my-run
+gremlin ideate --run-dir /tmp/my-run
+gremlin rollout --run-dir /tmp/my-run
+gremlin judge --run-dir /tmp/my-run
+```
+
+Each stage reads the previous stage's artifact and writes its own — `understanding.json` → `scenarios.json` → `results.json` → `scores.json`.
+
 ### 2. GitHub Action
 
 Add to any repo — Gremlin posts a risk report on every PR automatically.
@@ -190,14 +219,22 @@ pytest
 
 | Command | Description |
 |---------|-------------|
-| `gremlin review "scope"` | Analyze a feature for risks |
+| `gremlin review "scope"` | Full pipeline in one command |
 | `gremlin review "scope" --context @file` | With file context |
 | `git diff \| gremlin review "changes" --context -` | With diff via stdin |
 | `gremlin patterns list` | Show all pattern domains |
 | `gremlin patterns show payments` | Show patterns for a domain |
 | `gremlin learn "incident" --domain auth` | Learn from incidents |
+| `gremlin understand "scope"` | Stage 1 — infer domains (no LLM) |
+| `gremlin ideate` | Stage 2 — select patterns (no LLM) |
+| `gremlin rollout` | Stage 3 — call LLM |
+| `gremlin judge` | Stage 4 — parse and score risks |
 
 **`review` options:** `--depth quick|deep` · `--threshold 0-100` · `--output rich|md|json` · `--validate`
+
+**`understand` options:** `--depth quick|deep` · `--threshold 0-100` · `--run-dir PATH`
+
+**`judge` options:** `--validate` · `--run-dir PATH`
 
 ---
 

--- a/gremlin/__init__.py
+++ b/gremlin/__init__.py
@@ -1,6 +1,6 @@
 """Gremlin - Pre-Ship Risk Critic."""
 
-__version__ = "0.2.2"
+__version__ = "0.3.0"
 
 # Export main API classes for library usage
 from gremlin.api import AnalysisResult, Gremlin, Risk

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gremlin-critic"
-version = "0.2.2"
+version = "0.3.0"
 description = "Pre-ship risk critic (CLI + Python library) — surfaces breaking risk scenarios before they reach production"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bumps version `0.2.2 → 0.3.0` in `pyproject.toml` and `gremlin/__init__.py`
- Updates README with pipeline stage commands section (`understand` / `ideate` / `rollout` / `judge`) including usage examples and the artifact flow (`understanding.json → scenarios.json → results.json → scores.json`)
- Expands Commands table with all 4 stage commands and their options
- Adds `[0.3.0]` CHANGELOG entry covering all v0.3 additions and fixes

## What's in v0.3.0

- Decoupled pipeline stage CLI commands (`understand`, `ideate`, `rollout`, `judge`)
- Frozen stage dataclasses (immutable artifacts, no inter-stage corruption)
- Stage-tagged exceptions for faster debugging
- Atomic artifact writes in CLI
- Golden set recall evaluation (`evals/golden/`)
- `validate: bool = False` param on `Gremlin.analyze()`

## After merge

Publish to PyPI:
```bash
pip install build twine
python -m build
twine upload dist/*
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)