### PR TITLE
docs: add --run-dir to ideate/rollout options in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,8 @@ pytest
 
 **`understand` options:** `--depth quick|deep` · `--threshold 0-100` · `--run-dir PATH`
 
+**`ideate` / `rollout` options:** `--run-dir PATH`
+
 **`judge` options:** `--validate` · `--run-dir PATH`
 
 ---


### PR DESCRIPTION
Fixes a gap spotted in the PR #45 review: `ideate` and `rollout` both accept `--run-dir` but it wasn't listed in the Commands options footnotes. Adds `**`ideate` / `rollout` options:** `--run-dir PATH``.