### PR TITLE
feat: dashboard landing page + URL deep linking

### DIFF
--- a/dashboard/data/openclaw-results.json
+++ b/dashboard/data/openclaw-results.json
@@ -1,6 +1,30 @@
 {
   "target": "openclaw/openclaw",
   "url": "https://github.com/openclaw/openclaw",
+  "description": "Open-source personal AI assistant with WebSocket gateways, multi-channel messaging, voice processing, and device pairing.",
+  "highlights": [
+    {
+      "title": "WebSocket Frame Bomb Attack",
+      "severity": "CRITICAL",
+      "confidence": 95,
+      "area": "WebSocket Gateway",
+      "summary": "Malicious client sends crafted frames with claimed 2GB payload, exhausting memory instantly and crashing all channels."
+    },
+    {
+      "title": "Webhook Signature Replay Attack",
+      "severity": "CRITICAL",
+      "confidence": 95,
+      "area": "Multi-Channel Messaging",
+      "summary": "Captured webhook signatures replayed within validity window to inject forged messages across platforms."
+    },
+    {
+      "title": "Workspace Directory Takeover",
+      "severity": "CRITICAL",
+      "confidence": 95,
+      "area": "Session Persistence & State",
+      "summary": "Symlink attack on workspace directory allows arbitrary file read/write through the AI assistant runtime."
+    }
+  ],
   "date": "2026-02-15T22:30:00.000000",
   "gremlin_version": "0.2.0",
   "threshold": 70,

--- a/dashboard/data/openclaw-results.json
+++ b/dashboard/data/openclaw-results.json
@@ -1,30 +1,6 @@
 {
   "target": "openclaw/openclaw",
   "url": "https://github.com/openclaw/openclaw",
-  "description": "Open-source personal AI assistant with WebSocket gateways, multi-channel messaging, voice processing, and device pairing.",
-  "highlights": [
-    {
-      "title": "WebSocket Frame Bomb Attack",
-      "severity": "CRITICAL",
-      "confidence": 95,
-      "area": "WebSocket Gateway",
-      "summary": "Malicious client sends crafted frames with claimed 2GB payload, exhausting memory instantly and crashing all channels."
-    },
-    {
-      "title": "Webhook Signature Replay Attack",
-      "severity": "CRITICAL",
-      "confidence": 95,
-      "area": "Multi-Channel Messaging",
-      "summary": "Captured webhook signatures replayed within validity window to inject forged messages across platforms."
-    },
-    {
-      "title": "Workspace Directory Takeover",
-      "severity": "CRITICAL",
-      "confidence": 95,
-      "area": "Session Persistence & State",
-      "summary": "Symlink attack on workspace directory allows arbitrary file read/write through the AI assistant runtime."
-    }
-  ],
   "date": "2026-02-15T22:30:00.000000",
   "gremlin_version": "0.2.0",
   "threshold": 70,

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -404,6 +404,84 @@ body {
 .empty-state h2 { color: var(--text-secondary); margin-bottom: 12px; font-size: 1.2rem; }
 .empty-state p { max-width: 400px; margin: 0 auto; }
 
+/* ── Hero / Landing Section ──────────────────────────────────── */
+.hero {
+  background: linear-gradient(135deg, rgba(99,102,241,0.12) 0%, rgba(220,38,38,0.08) 100%);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 32px 28px;
+  margin-bottom: 24px;
+}
+.hero-title {
+  font-size: 1.8rem;
+  font-weight: 800;
+  margin-bottom: 8px;
+  line-height: 1.2;
+}
+.hero-title a { color: var(--text-primary); text-decoration: none; }
+.hero-title a:hover { color: var(--accent); }
+.hero-description {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  margin-bottom: 20px;
+  max-width: 700px;
+}
+.hero-stats {
+  display: flex;
+  gap: 24px;
+  margin-bottom: 24px;
+  flex-wrap: wrap;
+}
+.hero-stat {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+.hero-stat-value {
+  font-size: 1.6rem;
+  font-weight: 800;
+}
+.hero-stat-label {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+.hero-highlights {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 12px;
+}
+.hero-highlight {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 14px 16px;
+  border-left: 3px solid var(--critical);
+}
+.hero-highlight-title {
+  font-weight: 700;
+  font-size: 0.9rem;
+  margin-bottom: 4px;
+}
+.hero-highlight-meta {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  margin-bottom: 6px;
+}
+.hero-highlight-summary {
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+.hero-cta {
+  margin-top: 20px;
+  font-size: 0.85rem;
+  color: var(--accent);
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-block;
+}
+.hero-cta:hover { color: var(--accent-hover); text-decoration: underline; }
+
 /* ── Responsive ──────────────────────────────────────────────── */
 @media (max-width: 1024px) {
   .charts-row { grid-template-columns: 1fr; }
@@ -489,6 +567,7 @@ let chartDonut = null;
 let chartDomain = null;
 let tableSort = { col: 'severity', dir: 'asc' };
 let tableFilters = { severity: '', area: '', search: '' };
+let isDeepLinked = false;
 
 // ── Domain Normalization ─────────────────────────────────────────
 function normalizeDomains(rawDomains) {
@@ -581,7 +660,10 @@ function renderDashboard() {
   const domainStats = buildDomainStats(allRisks);
 
   const main = document.getElementById('mainContent');
+  const heroHtml = (isDeepLinked && currentData.description) ? renderHero(summary) : '';
   main.innerHTML = `
+    ${heroHtml}
+
     <!-- Project Banner -->
     <div class="project-banner">
       <div class="project-name">
@@ -679,6 +761,49 @@ function renderDashboard() {
   renderDomainChart(domainStats);
   renderRiskTable();
   bindTableEvents();
+}
+
+// ── Hero / Landing Section ────────────────────────────────────────
+function renderHero(summary) {
+  const d = currentData;
+  const nameHtml = d.url && /^https?:\/\//.test(d.url)
+    ? `<a href="${esc(d.url)}" target="_blank" rel="noopener">${esc(d.target)}</a>`
+    : esc(d.target);
+
+  const highlightsHtml = (d.highlights || []).map(h => `
+    <div class="hero-highlight">
+      <div class="hero-highlight-title">${esc(h.title)}</div>
+      <div class="hero-highlight-meta">${esc(h.severity)} &middot; ${h.confidence}% confidence &middot; ${esc(h.area)}</div>
+      <div class="hero-highlight-summary">${esc(h.summary)}</div>
+    </div>
+  `).join('');
+
+  return `
+    <div class="hero" id="heroSection">
+      <div class="hero-title">${nameHtml}</div>
+      <div class="hero-description">${esc(d.description)}</div>
+      <div class="hero-stats">
+        <div class="hero-stat">
+          <span class="hero-stat-value">${summary.total}</span>
+          <span class="hero-stat-label">risks found</span>
+        </div>
+        <div class="hero-stat">
+          <span class="hero-stat-value" style="color:var(--critical)">${summary.CRITICAL}</span>
+          <span class="hero-stat-label">critical</span>
+        </div>
+        <div class="hero-stat">
+          <span class="hero-stat-value" style="color:var(--high)">${summary.HIGH}</span>
+          <span class="hero-stat-label">high</span>
+        </div>
+        <div class="hero-stat">
+          <span class="hero-stat-value">${summary.areas}</span>
+          <span class="hero-stat-label">areas analyzed</span>
+        </div>
+      </div>
+      ${highlightsHtml ? `<div class="hero-highlights">${highlightsHtml}</div>` : ''}
+      <a class="hero-cta" onclick="document.querySelector('.charts-row').scrollIntoView({behavior:'smooth'})">View full dashboard &#8595;</a>
+    </div>
+  `;
 }
 
 // ── Heatmap Render ───────────────────────────────────────────────
@@ -942,13 +1067,31 @@ async function loadFromCatalog() {
     select.innerHTML = catalog.projects.map(p =>
       `<option value="${esc(p.file)}">${esc(p.name)}</option>`
     ).join('');
-    select.addEventListener('change', () => loadProject(select.value));
+    select.addEventListener('change', () => {
+      isDeepLinked = false;
+      loadProject(select.value);
+    });
 
-    // Check URL param
+    // Check URL params: ?project=<id> or ?file=<filename>
     const params = new URLSearchParams(window.location.search);
+    const projectParam = params.get('project');
     const fileParam = params.get('file');
-    if (fileParam) {
-      await loadProject(fileParam);
+    let targetFile = null;
+
+    if (projectParam) {
+      const match = catalog.projects.find(p => p.id === projectParam);
+      if (match) {
+        targetFile = match.file;
+        isDeepLinked = true;
+      }
+    } else if (fileParam) {
+      targetFile = fileParam;
+    }
+
+    if (targetFile) {
+      // Sync the dropdown to the deep-linked project
+      select.value = targetFile;
+      await loadProject(targetFile);
     } else if (catalog.projects.length) {
       await loadProject(catalog.projects[0].file);
     }

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -404,83 +404,67 @@ body {
 .empty-state h2 { color: var(--text-secondary); margin-bottom: 12px; font-size: 1.2rem; }
 .empty-state p { max-width: 400px; margin: 0 auto; }
 
-/* ── Hero / Landing Section ──────────────────────────────────── */
-.hero {
+/* ── Landing Page ────────────────────────────────────────────── */
+.landing {
   background: linear-gradient(135deg, rgba(99,102,241,0.12) 0%, rgba(220,38,38,0.08) 100%);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  padding: 32px 28px;
-  margin-bottom: 24px;
+  padding: 48px 32px;
+  text-align: center;
+  max-width: 720px;
+  margin: 60px auto;
 }
-.hero-title {
-  font-size: 1.8rem;
+.landing-title {
+  font-size: 2rem;
   font-weight: 800;
-  margin-bottom: 8px;
+  margin-bottom: 12px;
   line-height: 1.2;
 }
-.hero-title a { color: var(--text-primary); text-decoration: none; }
-.hero-title a:hover { color: var(--accent); }
-.hero-description {
+.landing-title span { color: var(--accent); }
+.landing-description {
   color: var(--text-secondary);
-  font-size: 1rem;
-  margin-bottom: 20px;
-  max-width: 700px;
+  font-size: 1.05rem;
+  margin-bottom: 28px;
+  max-width: 560px;
+  margin-left: auto;
+  margin-right: auto;
+  line-height: 1.6;
 }
-.hero-stats {
-  display: flex;
-  gap: 24px;
-  margin-bottom: 24px;
-  flex-wrap: wrap;
-}
-.hero-stat {
-  display: flex;
-  align-items: baseline;
-  gap: 6px;
-}
-.hero-stat-value {
-  font-size: 1.6rem;
-  font-weight: 800;
-}
-.hero-stat-label {
-  font-size: 0.85rem;
-  color: var(--text-secondary);
-}
-.hero-highlights {
+.landing-steps {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+  margin-bottom: 28px;
+  text-align: left;
 }
-.hero-highlight {
+.landing-step {
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  padding: 14px 16px;
-  border-left: 3px solid var(--critical);
+  padding: 16px;
 }
-.hero-highlight-title {
-  font-weight: 700;
-  font-size: 0.9rem;
-  margin-bottom: 4px;
-}
-.hero-highlight-meta {
+.landing-step-num {
   font-size: 0.75rem;
-  color: var(--text-muted);
+  font-weight: 700;
+  color: var(--accent);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
   margin-bottom: 6px;
 }
-.hero-highlight-summary {
-  font-size: 0.82rem;
+.landing-step-text {
+  font-size: 0.88rem;
   color: var(--text-secondary);
   line-height: 1.5;
 }
-.hero-cta {
-  margin-top: 20px;
-  font-size: 0.85rem;
+.landing-cta {
+  display: inline-block;
+  margin-top: 8px;
+  font-size: 0.9rem;
   color: var(--accent);
   cursor: pointer;
   text-decoration: none;
-  display: inline-block;
 }
-.hero-cta:hover { color: var(--accent-hover); text-decoration: underline; }
+.landing-cta:hover { color: var(--accent-hover); text-decoration: underline; }
 
 /* ── Responsive ──────────────────────────────────────────────── */
 @media (max-width: 1024px) {
@@ -567,7 +551,7 @@ let chartDonut = null;
 let chartDomain = null;
 let tableSort = { col: 'severity', dir: 'asc' };
 let tableFilters = { severity: '', area: '', search: '' };
-let isDeepLinked = false;
+// Landing page shown when no project is selected
 
 // ── Domain Normalization ─────────────────────────────────────────
 function normalizeDomains(rawDomains) {
@@ -660,10 +644,7 @@ function renderDashboard() {
   const domainStats = buildDomainStats(allRisks);
 
   const main = document.getElementById('mainContent');
-  const heroHtml = (isDeepLinked && currentData.description) ? renderHero(summary) : '';
   main.innerHTML = `
-    ${heroHtml}
-
     <!-- Project Banner -->
     <div class="project-banner">
       <div class="project-name">
@@ -763,45 +744,35 @@ function renderDashboard() {
   bindTableEvents();
 }
 
-// ── Hero / Landing Section ────────────────────────────────────────
-function renderHero(summary) {
-  const d = currentData;
-  const nameHtml = d.url && /^https?:\/\//.test(d.url)
-    ? `<a href="${esc(d.url)}" target="_blank" rel="noopener">${esc(d.target)}</a>`
-    : esc(d.target);
+// ── Landing Page ──────────────────────────────────────────────────
+function renderLanding(catalog) {
+  const projectList = catalog.projects.map(p =>
+    `<a class="landing-cta" href="?project=${encodeURIComponent(p.id)}">${esc(p.name)}</a>`
+  ).join(' &nbsp;&middot;&nbsp; ');
 
-  const highlightsHtml = (d.highlights || []).map(h => `
-    <div class="hero-highlight">
-      <div class="hero-highlight-title">${esc(h.title)}</div>
-      <div class="hero-highlight-meta">${esc(h.severity)} &middot; ${h.confidence}% confidence &middot; ${esc(h.area)}</div>
-      <div class="hero-highlight-summary">${esc(h.summary)}</div>
-    </div>
-  `).join('');
-
-  return `
-    <div class="hero" id="heroSection">
-      <div class="hero-title">${nameHtml}</div>
-      <div class="hero-description">${esc(d.description)}</div>
-      <div class="hero-stats">
-        <div class="hero-stat">
-          <span class="hero-stat-value">${summary.total}</span>
-          <span class="hero-stat-label">risks found</span>
+  const main = document.getElementById('mainContent');
+  main.innerHTML = `
+    <div class="landing">
+      <div class="landing-title"><span>Gremlin</span> Risk Dashboard</div>
+      <div class="landing-description">
+        Explore pre-ship risk analysis powered by 107 QA patterns across 14 domains.
+        Each project below has been analyzed for critical, high, medium, and low severity risks.
+      </div>
+      <div class="landing-steps">
+        <div class="landing-step">
+          <div class="landing-step-num">Step 1</div>
+          <div class="landing-step-text">Select a project from the dropdown above or click a link below to view its risk analysis.</div>
         </div>
-        <div class="hero-stat">
-          <span class="hero-stat-value" style="color:var(--critical)">${summary.CRITICAL}</span>
-          <span class="hero-stat-label">critical</span>
+        <div class="landing-step">
+          <div class="landing-step-num">Step 2</div>
+          <div class="landing-step-text">Browse the heatmap to see risk distribution across feature areas and severity levels.</div>
         </div>
-        <div class="hero-stat">
-          <span class="hero-stat-value" style="color:var(--high)">${summary.HIGH}</span>
-          <span class="hero-stat-label">high</span>
-        </div>
-        <div class="hero-stat">
-          <span class="hero-stat-value">${summary.areas}</span>
-          <span class="hero-stat-label">areas analyzed</span>
+        <div class="landing-step">
+          <div class="landing-step-num">Step 3</div>
+          <div class="landing-step-text">Filter and search the risk table. Click any row to expand the full scenario and impact.</div>
         </div>
       </div>
-      ${highlightsHtml ? `<div class="hero-highlights">${highlightsHtml}</div>` : ''}
-      <a class="hero-cta" onclick="document.querySelector('.charts-row').scrollIntoView({behavior:'smooth'})">View full dashboard &#8595;</a>
+      <div>${projectList}</div>
     </div>
   `;
 }
@@ -1064,12 +1035,23 @@ async function loadFromCatalog() {
     if (!res.ok) throw new Error('Catalog not found');
     const catalog = await res.json();
     const select = document.getElementById('projectSelect');
-    select.innerHTML = catalog.projects.map(p =>
-      `<option value="${esc(p.file)}">${esc(p.name)}</option>`
-    ).join('');
+    select.innerHTML = '<option value="">— Select a project —</option>' +
+      catalog.projects.map(p =>
+        `<option value="${esc(p.file)}" data-id="${esc(p.id)}">${esc(p.name)}</option>`
+      ).join('');
     select.addEventListener('change', () => {
-      isDeepLinked = false;
-      loadProject(select.value);
+      const opt = select.selectedOptions[0];
+      const id = opt ? opt.dataset.id : '';
+      if (id) {
+        history.replaceState(null, '', '?project=' + encodeURIComponent(id));
+      } else {
+        history.replaceState(null, '', window.location.pathname);
+      }
+      if (select.value) {
+        loadProject(select.value);
+      } else {
+        renderLanding(catalog);
+      }
     });
 
     // Check URL params: ?project=<id> or ?file=<filename>
@@ -1089,11 +1071,10 @@ async function loadFromCatalog() {
     }
 
     if (targetFile) {
-      // Sync the dropdown to the deep-linked project
       select.value = targetFile;
       await loadProject(targetFile);
-    } else if (catalog.projects.length) {
-      await loadProject(catalog.projects[0].file);
+    } else {
+      renderLanding(catalog);
     }
   } catch {
     showEmpty('No data catalog found. Upload a Gremlin results JSON to get started.');

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1074,7 +1074,8 @@ async function loadFromCatalog() {
         targetFile = match.file;
       }
     } else if (fileParam) {
-      targetFile = fileParam;
+      const fileMatch = catalog.projects.find(p => p.file === fileParam);
+      if (fileMatch) targetFile = fileParam;
     }
 
     if (targetFile) {

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -493,7 +493,7 @@ body {
 <!-- Header -->
 <header class="header">
   <div>
-    <div class="header-logo">Gremlin <span>Risk Dashboard</span> <small style="opacity:0.5;font-size:0.6em;font-weight:400;">v2.0</small></div>
+    <a class="header-logo" href="./" style="text-decoration:none">Gremlin <span>Risk Dashboard</span> <small style="opacity:0.5;font-size:0.6em;font-weight:400;">v2.0</small></a>
     <div class="header-description">
       AI-powered risk analysis with 107 QA patterns — visualize critical scenarios across security, concurrency, payments, and more.
     </div>
@@ -1039,6 +1039,14 @@ async function loadFromCatalog() {
       catalog.projects.map(p =>
         `<option value="${esc(p.file)}" data-id="${esc(p.id)}">${esc(p.name)}</option>`
       ).join('');
+    // Logo click → landing page
+    document.querySelector('.header-logo').addEventListener('click', (e) => {
+      e.preventDefault();
+      select.value = '';
+      history.replaceState(null, '', window.location.pathname);
+      renderLanding(catalog);
+    });
+
     select.addEventListener('change', () => {
       const opt = select.selectedOptions[0];
       const id = opt ? opt.dataset.id : '';
@@ -1064,7 +1072,6 @@ async function loadFromCatalog() {
       const match = catalog.projects.find(p => p.id === projectParam);
       if (match) {
         targetFile = match.file;
-        isDeepLinked = true;
       }
     } else if (fileParam) {
       targetFile = fileParam;

--- a/tests/test_dashboard_data.py
+++ b/tests/test_dashboard_data.py
@@ -99,3 +99,70 @@ def test_no_duplicate_filenames():
 
     files = [p["file"] for p in catalog["projects"]]
     assert len(files) == len(set(files)), f"Duplicate filenames: {files}"
+
+
+# ── URL query param & landing page tests ─────────────────────────
+
+
+def test_catalog_projects_have_id_for_url_param():
+    """Test that every catalog project has an 'id' field for ?project= deep linking."""
+    catalog_path = Path("dashboard/data/catalog.json")
+    with open(catalog_path) as f:
+        catalog = json.load(f)
+
+    for project in catalog["projects"]:
+        assert "id" in project, f"Project missing 'id': {project}"
+        assert isinstance(project["id"], str) and project["id"].strip(), (
+            f"Project 'id' must be a non-empty string: {project}"
+        )
+
+
+def test_project_param_resolves_to_valid_file():
+    """Test that each catalog project id maps to an existing data file."""
+    catalog_path = Path("dashboard/data/catalog.json")
+    with open(catalog_path) as f:
+        catalog = json.load(f)
+
+    for project in catalog["projects"]:
+        file_path = Path("dashboard/data") / project["file"]
+        assert file_path.exists(), (
+            f"?project={project['id']} would resolve to {project['file']} but file is missing"
+        )
+
+
+def test_dashboard_html_reads_project_query_param():
+    """Smoke test that dashboard JS contains ?project= param handling."""
+    html_path = Path("dashboard/index.html")
+    html = html_path.read_text()
+    assert "params.get('project')" in html, (
+        "Dashboard JS must read the 'project' query parameter"
+    )
+
+
+def test_openclaw_has_landing_page_fields():
+    """Test that openclaw results have description and highlights for the landing page."""
+    data_path = Path("dashboard/data/openclaw-results.json")
+    with open(data_path) as f:
+        data = json.load(f)
+
+    assert "description" in data, "openclaw-results.json missing 'description'"
+    assert isinstance(data["description"], str) and data["description"].strip()
+
+    assert "highlights" in data, "openclaw-results.json missing 'highlights'"
+    assert isinstance(data["highlights"], list)
+    assert len(data["highlights"]) > 0, "highlights must not be empty"
+
+    required = {"title", "severity", "confidence", "area", "summary"}
+    for i, h in enumerate(data["highlights"]):
+        missing = required - set(h.keys())
+        assert not missing, f"highlight {i} missing fields: {missing}"
+
+
+def test_dashboard_html_renders_hero_section():
+    """Smoke test that dashboard HTML/JS contains hero rendering logic."""
+    html_path = Path("dashboard/index.html")
+    html = html_path.read_text()
+    assert "renderHero" in html, "Dashboard must have renderHero function"
+    assert "hero-description" in html, "Dashboard must have hero-description CSS class"
+    assert "hero-highlights" in html, "Dashboard must have hero-highlights CSS class"
+    assert "isDeepLinked" in html, "Dashboard must track deep-link state"

--- a/tests/test_dashboard_data.py
+++ b/tests/test_dashboard_data.py
@@ -139,30 +139,19 @@ def test_dashboard_html_reads_project_query_param():
     )
 
 
-def test_openclaw_has_landing_page_fields():
-    """Test that openclaw results have description and highlights for the landing page."""
-    data_path = Path("dashboard/data/openclaw-results.json")
-    with open(data_path) as f:
-        data = json.load(f)
-
-    assert "description" in data, "openclaw-results.json missing 'description'"
-    assert isinstance(data["description"], str) and data["description"].strip()
-
-    assert "highlights" in data, "openclaw-results.json missing 'highlights'"
-    assert isinstance(data["highlights"], list)
-    assert len(data["highlights"]) > 0, "highlights must not be empty"
-
-    required = {"title", "severity", "confidence", "area", "summary"}
-    for i, h in enumerate(data["highlights"]):
-        missing = required - set(h.keys())
-        assert not missing, f"highlight {i} missing fields: {missing}"
-
-
-def test_dashboard_html_renders_hero_section():
-    """Smoke test that dashboard HTML/JS contains hero rendering logic."""
+def test_dashboard_html_renders_landing_page():
+    """Smoke test that dashboard HTML/JS contains landing page rendering logic."""
     html_path = Path("dashboard/index.html")
     html = html_path.read_text()
-    assert "renderHero" in html, "Dashboard must have renderHero function"
-    assert "hero-description" in html, "Dashboard must have hero-description CSS class"
-    assert "hero-highlights" in html, "Dashboard must have hero-highlights CSS class"
-    assert "isDeepLinked" in html, "Dashboard must track deep-link state"
+    assert "renderLanding" in html, "Dashboard must have renderLanding function"
+    assert "landing-title" in html, "Dashboard must have landing-title CSS class"
+    assert "landing-description" in html, "Dashboard must have landing-description CSS class"
+
+
+def test_dashboard_html_syncs_url_on_change():
+    """Smoke test that dropdown change updates the browser URL."""
+    html_path = Path("dashboard/index.html")
+    html = html_path.read_text()
+    assert "history.replaceState" in html, (
+        "Dashboard must use history.replaceState to sync URL on project change"
+    )


### PR DESCRIPTION
## Summary
- Generic landing page at `/` explaining what the dashboard is and how to navigate (no project results rendered)
- `?project=<id>` deep linking support (e.g. `?project=openclaw`)
- URL syncs with dropdown changes via `history.replaceState`
- Header logo click returns to landing page
- 5 new smoke tests for URL params, landing page, and URL sync

## Test plan
- [x] All 12 dashboard data tests pass
- [x] Full test suite passes (131 tests)
- [x] Linter clean
